### PR TITLE
Added ship gain/loss graph; Planet Ids + Numeric growth rates

### DIFF
--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -12,8 +12,9 @@ var Visualizer = {
     dirtyRegions: [],
     config : {
       planet_font: 'bold 15px Arial,Helvetica',
+      planet_id_font: '8px Helvetica,Arial',
       fleet_font: 'normal 12px Arial,Helvetica',
-      planet_pixels: [10,13,18,21,23,29],
+      planet_pixels: [16,19,22,25,28,31],
       showFleetText: true,
       display_size: 640,
       display_margin: 50,
@@ -75,7 +76,6 @@ var Visualizer = {
         this.drawBackground();
         
         // Draw Planets
-        ctx.font = this.config.planet_font;
         ctx.textAlign = 'center';
         for(var i = 0; i < this.planets.length; i++) {
             var planet = this.planets[i];
@@ -101,7 +101,10 @@ var Visualizer = {
             ctx.fill();
 
             ctx.fillStyle = "#fff";
-            ctx.fillText(planet.numShips, disp_x, this.canvas.height - disp_y + 5);
+            ctx.font = this.config.planet_id_font;
+            ctx.fillText("I:" + i + " G:" + planet.growthRate, disp_x, this.canvas.height - disp_y - 5);
+            ctx.font = this.config.planet_font;
+            ctx.fillText(planet.numShips, disp_x, this.canvas.height - disp_y + 10);
         }
         
         // Draw Fleets

--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -18,7 +18,8 @@ var Visualizer = {
       display_size: 640,
       display_margin: 50,
       turnsPerSecond: 8,
-      teamColor: ['#455','#c00','#7ac']
+      teamColor: ['#455','#c00','#7ac'],
+      teamColor2: ['#455', '#920', '#779']
     },
     
     setup: function(data) {
@@ -198,6 +199,30 @@ var Visualizer = {
             ctx.arc((j-1)*widthFactor, shipCount*heightFactor, 2, 0, Math.PI*2, true);
             ctx.fill();
         }
+
+
+        var middle = canvas.height / 2;
+        ctx.beginPath();
+        ctx.strokeStyle = "#90A8B0";
+        ctx.moveTo(0, middle);
+        ctx.lineTo(this.moves.length * widthFactor, middle)
+        ctx.stroke();
+        var lastCount, diff, shipCount;
+        for(var i = 1; i <= 2; i++ ){
+            ctx.strokeStyle = this.config.teamColor2[i];
+            ctx.fillStyle = this.config.teamColor2[i];
+            ctx.beginPath();
+            ctx.moveTo(0, middle);
+            lastCount = 0;
+            for(var j=1; j < this.moves.length; j++ ){
+                shipCount = this.moves[j].shipCount[i];
+                diff = (shipCount  - lastCount);
+                ctx.lineTo(j*widthFactor, (diff * heightFactor * 4) + middle);
+                lastCount = shipCount;
+            }
+            ctx.stroke();
+        }
+
         
     },
     


### PR DESCRIPTION
Hi, 
I've added two things:
- a gain/loss graph to the total ship count graph at the bottom
- Id and numeric growth to the planets

Here is how it looks:
http://ulo.pe/pw-canvas-vis/

I find it eases following a match from debug output very much (esp. the planet ids)
